### PR TITLE
add missing chalk dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "command line sbot",
   "main": "publish.js",
   "dependencies": {
+    "chalk": "^1.1.3",
     "moment": "^2.15.0",
     "promptly": "^2.1.0",
     "pull-paramap": "^1.1.6",


### PR DESCRIPTION
publish.js and seven.js both fail if you don't have chalk installed, so I added it to package.json.